### PR TITLE
요청 본문 파싱 시 클라이언트에 지나치게 상세한 로그 전송 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/common/error/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/common/error/handler/GlobalExceptionHandler.kt
@@ -55,7 +55,7 @@ class GlobalExceptionHandler(
     fun handleHttpMessageNotReadable(ex: HttpMessageNotReadableException): CommonApiResponse<Nothing> {
         warnTrace("HttpMessageNotReadable", ex)
         return CommonApiResponse.error(
-            message = "요청 본문을 읽을 수 없습니다: ${ex.mostSpecificCause.message}",
+            message = "요청 본문을 읽을 수 없습니다.",
             status = HttpStatus.BAD_REQUEST,
         )
     }


### PR DESCRIPTION
## 작업 내용
> GlobalExceptionHandler에서 요청본문을 파싱 하는데 실패할 시 클라이언트에게 반환 되는 반응에 지나치게 많은 세부정보가 포함되던 것을 제거하였습니다.

아래는 기존 작업 전 세부정보가 포함된 응답입니다.
```json
{
    "status": "BAD_REQUEST",
    "code": 400,
    "message": "요청 본문을 읽을 수 없습니다: Instantiation of [simple type, class com.team.incube.gsmc.v3.domain.auth.presentation.data.request.TokenRefreshRequest] value failed for JSON property refreshToken due to missing (therefore NULL) value for creator parameter refreshToken which is a non-nullable type\n at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 3, column: 1] (through reference chain: com.team.incube.gsmc.v3.domain.auth.presentation.data.request.TokenRefreshRequest["refreshToken"])"
}
```

## 리뷰 시 참고사항
> @snowykte0426 님과 함께 작업했습니다.

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?