### PR TITLE
인증제 항목 기준 인증제 점수 반환 서비스에서 인증제 항목이 응답에 포함되는 기준 변경

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/service/impl/FindScoresByCategoryServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/service/impl/FindScoresByCategoryServiceImpl.kt
@@ -30,15 +30,14 @@ class FindScoresByCategoryServiceImpl(
                     status = status,
                 )
 
-            val groupedByCategory = groupScoresByCategory(scores)
             val foreignLanguageCategories = CategoryType.getForeignLanguageCategories()
-            val foreignRepresentative = groupedByCategory.keys.find { it in foreignLanguageCategories } ?: CategoryType.TOEIC
+            val groupingResult = groupScoresByCategory(scores, foreignLanguageCategories)
 
             val categoryGroups =
                 CategoryType.entries
-                    .filter { !it.isForeignLanguage || it == foreignRepresentative }
+                    .filter { !it.isForeignLanguage || it == groupingResult.foreignRepresentative }
                     .map { categoryType ->
-                        val categoryScores = groupedByCategory[categoryType] ?: emptyList()
+                        val categoryScores = groupingResult.groupedScores[categoryType] ?: emptyList()
                         val recognizedScore = if (categoryScores.isNotEmpty()) calculateRecognizedScore(categoryScores, categoryType) else 0
                         val isForeignLanguage = categoryType.isForeignLanguage
 
@@ -71,25 +70,36 @@ class FindScoresByCategoryServiceImpl(
             GetScoresByCategoryResponse(categories = categoryGroups)
         }
 
-    private fun groupScoresByCategory(scores: List<Score>): Map<CategoryType, List<Score>> {
-        val foreignLanguageCategories = CategoryType.getForeignLanguageCategories()
+    private data class GroupingResult(
+        val groupedScores: Map<CategoryType, List<Score>>,
+        val foreignRepresentative: CategoryType,
+    )
+
+    private fun groupScoresByCategory(
+        scores: List<Score>,
+        foreignLanguageCategories: List<CategoryType>,
+    ): GroupingResult {
         val (foreignLanguageScores, otherScores) = scores.partition { it.categoryType in foreignLanguageCategories }
 
         val grouped = mutableMapOf<CategoryType, List<Score>>()
 
-        if (foreignLanguageScores.isNotEmpty()) {
-            val representativeCategory =
+        val representativeCategory =
+            if (foreignLanguageScores.isNotEmpty()) {
                 when {
                     foreignLanguageScores.any { it.categoryType == CategoryType.TOEIC } -> CategoryType.TOEIC
                     foreignLanguageScores.any { it.categoryType == CategoryType.JLPT } -> CategoryType.JLPT
                     else -> CategoryType.TOEIC
-                }
-            grouped[representativeCategory] = foreignLanguageScores
-        }
+                }.also { grouped[it] = foreignLanguageScores }
+            } else {
+                CategoryType.TOEIC
+            }
 
         grouped.putAll(otherScores.groupBy { it.categoryType })
 
-        return grouped
+        return GroupingResult(
+            groupedScores = grouped,
+            foreignRepresentative = representativeCategory,
+        )
     }
 
     private fun calculateRecognizedScore(


### PR DESCRIPTION
## 작업 내용
> #78 인증제 항목 별 인증제 점수를 조회하는 API에서 비즈니스 요구사항이 변경되어 현재 인증된 사용자에게 해당 해당 항목에 대한 점수가 없더라도 응답에서 해당하는 항목을 제외하는 것이 아닌 해당하는 항목의 값을 `0` 또는 `[]`로 전달하도록 수정하였습니다.

## 리뷰 시 참고사항
> 

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?