### PR TITLE
Redis 객체 역직렬화 과정에서 생성자 적용 실패 문제 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/config/RedisCacheConfig.kt
@@ -24,7 +24,7 @@ class RedisCacheConfig {
                 activateDefaultTyping(
                     BasicPolymorphicTypeValidator
                         .builder()
-                        .allowIfBaseType(Any::class.java)
+                        .allowIfSubType("com.team.incube.gsmc.v3")
                         .build(),
                     ObjectMapper.DefaultTyping.NON_FINAL,
                 )


### PR DESCRIPTION
## 작업 내용
> Redis 객체의 역직렬화 과정에서 생성자 적용이 되지 않아 오류가 발생하던 것을 수정하였습니다.
<img width="533" height="812" alt="image" src="https://github.com/user-attachments/assets/d8fc4dd9-e339-475b-bdd6-5d486c999bce" />


## 리뷰 시 참고사항
> 
## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?