### PR TITLE
증빙자료 임시저장 시 인증제 점수를 매핑하지 않도록 변경

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/request/CreateEvidenceDraftRequest.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/request/CreateEvidenceDraftRequest.kt
@@ -4,8 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "증빙자료 임시저장 생성 요청")
 data class CreateEvidenceDraftRequest(
-    @param:Schema(description = "점수 ID", example = "1")
-    val scoreId: Long? = null,
     @param:Schema(description = "증빙자료 제목", example = "대회 참가 증빙")
     val title: String = "",
     @param:Schema(description = "증빙자료 내용", example = "2024년 전국 프로그래밍 대회 참가 증빙자료입니다.")

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/response/GetEvidenceDraftResponse.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/response/GetEvidenceDraftResponse.kt
@@ -5,8 +5,6 @@ import java.io.Serializable
 
 @Schema(description = "증빙자료 임시저장 조회 응답")
 data class GetEvidenceDraftResponse(
-    @param:Schema(description = "점수 ID", example = "1")
-    val scoreId: Long?,
     @param:Schema(description = "증빙자료 제목", example = "대회 참가 증빙")
     val title: String,
     @param:Schema(description = "증빙자료 내용", example = "2024년 전국 프로그래밍 대회 참가 증빙자료입니다.")

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/impl/CreateEvidenceDraftServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/impl/CreateEvidenceDraftServiceImpl.kt
@@ -14,7 +14,6 @@ class CreateEvidenceDraftServiceImpl(
     @CachePut(value = ["evidenceDraft"], key = "#root.target.getMemberId()")
     override fun execute(request: CreateEvidenceDraftRequest): GetEvidenceDraftResponse =
         GetEvidenceDraftResponse(
-            scoreId = request.scoreId,
             title = request.title,
             content = request.content,
             fileIds = request.fileIds,

--- a/src/test/kotlin/com/team/incube/gsmc/v3/service/evidence/CreateEvidenceDraftServiceTest.kt
+++ b/src/test/kotlin/com/team/incube/gsmc/v3/service/evidence/CreateEvidenceDraftServiceTest.kt
@@ -39,7 +39,6 @@ class CreateEvidenceDraftServiceTest :
 
             val request =
                 CreateEvidenceDraftRequest(
-                    scoreId = 10L,
                     title = "대회 참가 증빙",
                     content = "2024년 전국 프로그래밍 대회 참가 증빙자료입니다.",
                     fileIds = listOf(1L, 2L),
@@ -53,7 +52,6 @@ class CreateEvidenceDraftServiceTest :
                 Then("요청한 데이터가 응답으로 반환된다") {
                     result shouldBe
                         GetEvidenceDraftResponse(
-                            scoreId = 10L,
                             title = "대회 참가 증빙",
                             content = "2024년 전국 프로그래밍 대회 참가 증빙자료입니다.",
                             fileIds = listOf(1L, 2L),
@@ -77,7 +75,6 @@ class CreateEvidenceDraftServiceTest :
 
             val request =
                 CreateEvidenceDraftRequest(
-                    scoreId = null,
                     title = "",
                     content = "",
                     fileIds = emptyList(),
@@ -91,7 +88,6 @@ class CreateEvidenceDraftServiceTest :
                 Then("빈 데이터가 응답으로 반환된다") {
                     result shouldBe
                         GetEvidenceDraftResponse(
-                            scoreId = null,
                             title = "",
                             content = "",
                             fileIds = emptyList(),
@@ -115,7 +111,6 @@ class CreateEvidenceDraftServiceTest :
 
             val request =
                 CreateEvidenceDraftRequest(
-                    scoreId = 5L,
                     title = "임시 제목",
                     content = "",
                     fileIds = listOf(1L),
@@ -127,7 +122,6 @@ class CreateEvidenceDraftServiceTest :
                 val result = c.service.execute(request)
 
                 Then("입력된 필드만 포함된 응답이 반환된다") {
-                    result.scoreId shouldBe 5L
                     result.title shouldBe "임시 제목"
                     result.content shouldBe ""
                     result.fileIds shouldBe listOf(1L)


### PR DESCRIPTION
## 작업 내용
> #107 해당 리뷰 반영하여 증빙자료 임시저장 시 인증제 점수 객체를 받지 않도록 수정하였습니다.

## 리뷰 시 참고사항
>

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?