### PR TITLE
증빙자료 수정 시 인증제 점수 대신 참가자 정보를 입력받던 것을 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/EvidenceController.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/EvidenceController.kt
@@ -121,7 +121,7 @@ class EvidenceController(
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "존재하지 않는 참가자를 매핑함 또는 존재하지 않는 증빙자료를 사용함",
+                description = "존재하지 않는 점수 객체 또는 존재하지 않는 증빙자료를 사용함",
                 content = [Content()],
             ),
         ],
@@ -134,7 +134,7 @@ class EvidenceController(
     ): PatchEvidenceResponse =
         updateEvidenceService.execute(
             evidenceId = evidenceId,
-            participantId = request.participantId,
+            scoreId = request.scoreId,
             title = request.title,
             content = request.content,
             fileIds = request.fileIds,

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/request/PatchEvidenceRequest.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/request/PatchEvidenceRequest.kt
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "증빙자료 수정 요청")
 data class PatchEvidenceRequest(
-    @param:Schema(description = "참가자 ID", example = "1", nullable = true)
-    val participantId: Long? = null,
+    @param:Schema(description = "점수 ID", example = "1", nullable = true)
+    val scoreId: Long? = null,
     @param:Schema(description = "증빙자료 제목", example = "대회 참가 증빙", nullable = true)
     val title: String? = null,
     @param:Schema(description = "증빙자료 내용", example = "2024년 전국 프로그래밍 대회 참가 증빙자료입니다.", nullable = true)

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/UpdateEvidenceService.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/UpdateEvidenceService.kt
@@ -5,7 +5,7 @@ import com.team.incube.gsmc.v3.domain.evidence.presentation.data.response.PatchE
 interface UpdateEvidenceService {
     fun execute(
         evidenceId: Long,
-        participantId: Long?,
+        scoreId: Long?,
         title: String?,
         content: String?,
         fileIds: List<Long>?,

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/impl/UpdateEvidenceServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/service/impl/UpdateEvidenceServiceImpl.kt
@@ -19,7 +19,7 @@ class UpdateEvidenceServiceImpl(
 ) : UpdateEvidenceService {
     override fun execute(
         evidenceId: Long,
-        participantId: Long?,
+        scoreId: Long?,
         title: String?,
         content: String?,
         fileIds: List<Long>?,
@@ -33,12 +33,12 @@ class UpdateEvidenceServiceImpl(
                 throw GsmcException(ErrorCode.FILE_NOT_FOUND)
             }
 
-            if (participantId != null) {
-                if (!scoreExposedRepository.existsById(participantId)) {
+            if (scoreId != null) {
+                if (!scoreExposedRepository.existsById(scoreId)) {
                     throw GsmcException(ErrorCode.SCORE_NOT_FOUND)
                 }
                 scoreExposedRepository.updateSourceIdToNull(evidenceId)
-                scoreExposedRepository.updateSourceId(participantId, evidenceId)
+                scoreExposedRepository.updateSourceId(scoreId, evidenceId)
             }
 
             val updatedEvidence =

--- a/src/test/kotlin/com/team/incube/gsmc/v3/service/evidence/UpdateEvidenceServiceTest.kt
+++ b/src/test/kotlin/com/team/incube/gsmc/v3/service/evidence/UpdateEvidenceServiceTest.kt
@@ -51,7 +51,7 @@ class UpdateEvidenceServiceTest :
         }
         afterTest { unmockkStatic("org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt") }
 
-        Given("증빙이 존재하고 참여자와 파일이 모두 변경되는 경우") {
+        Given("증빙이 존재하고 점수와 파일이 모두 변경되는 경우") {
             val c = ctx()
             val id = 1L
             val userId = 1L
@@ -67,7 +67,7 @@ class UpdateEvidenceServiceTest :
                     updatedAt = now,
                     files = originFiles,
                 )
-            val newParticipantId = 100L
+            val newScoreId = 100L
             val newFileIds = listOf(20L, 21L)
             val updatedFiles =
                 listOf(
@@ -87,16 +87,16 @@ class UpdateEvidenceServiceTest :
 
             every { c.evidenceRepo.findById(id) } returns found
             every { c.fileRepo.existsByIdIn(newFileIds) } returns true
-            every { c.scoreRepo.existsById(newParticipantId) } returns true
+            every { c.scoreRepo.existsById(newScoreId) } returns true
             justRun { c.scoreRepo.updateSourceIdToNull(id) }
-            justRun { c.scoreRepo.updateSourceId(newParticipantId, id) }
+            justRun { c.scoreRepo.updateSourceId(newScoreId, id) }
             every {
                 c.evidenceRepo.update(id = id, title = "new-title", content = "new-content", fileIds = newFileIds)
             } returns updated
 
             When("execute를 호출하면") {
                 val res: PatchEvidenceResponse =
-                    c.service.execute(id, newParticipantId, "new-title", "new-content", newFileIds)
+                    c.service.execute(id, newScoreId, "new-title", "new-content", newFileIds)
 
                 Then("수정된 정보가 반환된다") {
                     res shouldNotBe null
@@ -110,11 +110,11 @@ class UpdateEvidenceServiceTest :
                         )
                 }
 
-                Then("참여자 재매핑 및 파일 검증/업데이트가 수행된다") {
+                Then("점수 재매핑 및 파일 검증/업데이트가 수행된다") {
                     verify(exactly = 1) { c.fileRepo.existsByIdIn(newFileIds) }
-                    verify(exactly = 1) { c.scoreRepo.existsById(newParticipantId) }
+                    verify(exactly = 1) { c.scoreRepo.existsById(newScoreId) }
                     verify(exactly = 1) { c.scoreRepo.updateSourceIdToNull(id) }
-                    verify(exactly = 1) { c.scoreRepo.updateSourceId(newParticipantId, id) }
+                    verify(exactly = 1) { c.scoreRepo.updateSourceId(newScoreId, id) }
                     verify(exactly = 1) {
                         c.evidenceRepo.update(
                             id = id,
@@ -157,7 +157,7 @@ class UpdateEvidenceServiceTest :
             }
         }
 
-        Given("참여자 ID가 주어졌지만 존재하지 않을 때") {
+        Given("점수 ID가 주어졌지만 존재하지 않을 때") {
             val c = ctx()
             val id = 1L
             val userId = 1L
@@ -186,7 +186,7 @@ class UpdateEvidenceServiceTest :
             }
         }
 
-        Given("타이틀/내용/파일/참여자 모두 null이면 기존 값으로 업데이트 된다") {
+        Given("타이틀/내용/파일/점수 모두 null이면 기존 값으로 업데이트 된다") {
             val c = ctx()
             val id = 1L
             val userId = 1L


### PR DESCRIPTION
## 작업 내용
> 증빙자료 수정 시 데이터 구조와 다르게 인증제 점수 대신 참가자 정보를 입력받도록 필드 명칭이 되어 있던 것을 수정하였습니다.

## 리뷰 시 참고사항
> 

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?