### PR TITLE
임시저장 시 `null` 값이 저장되었을 때 문제 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/config/RedisCacheConfig.kt
@@ -29,7 +29,7 @@ class RedisCacheConfig {
                         .allowIfSubType("com.team.incube.gsmc.v3")
                         .build(),
                     ObjectMapper.DefaultTyping.NON_FINAL,
-                    JsonTypeInfo.As.PROPERTY
+                    JsonTypeInfo.As.PROPERTY,
                 )
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
             }


### PR DESCRIPTION
## 작업 내용
> 임시저장이 Redis 캐싱을 기반으로 구현되어 있는데 `null`이 캐싱되어 직렬화/역직렬화 과정에서 불일치가 발생하던 것을 수정하였습니다.

## 리뷰 시 참고사항
> 

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?