### PR TITLE
Redis 캐싱 시 객체가 `Serializable`를 구현하고 있던 것을 제거

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/response/GetEvidenceDraftResponse.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/evidence/presentation/data/response/GetEvidenceDraftResponse.kt
@@ -1,7 +1,6 @@
 package com.team.incube.gsmc.v3.domain.evidence.presentation.data.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import java.io.Serializable
 
 @Schema(description = "증빙자료 임시저장 조회 응답")
 data class GetEvidenceDraftResponse(
@@ -11,4 +10,4 @@ data class GetEvidenceDraftResponse(
     val content: String,
     @param:Schema(description = "파일 ID 목록", example = "[1, 2]")
     val fileIds: List<Long>,
-) : Serializable
+)


### PR DESCRIPTION
## 작업 내용
> #117 해당 이슈의 해결을 위하여 객체가 명시적으로 가지고 있던 `Serializable` 속성을 제거하였습니다.

## 리뷰 시 참고사항
>

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?