### PR TITLE
개발자용 API에서 중복된 쿼리 메서드 제거

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
@@ -59,14 +59,12 @@ class DeleteMemberByEmailServiceImpl(
                                     fileExposedRepository.deleteById(it.id)
                                 }
                             }
-
                             EvidenceType.UNREQUIRED -> {
                             }
                         }
                     }
                 }
-
-                scoreExposedRepository.deleteByIdIn(scoreIds)
+                scoreExposedRepository.deleteAllByIdIn(scoreIds)
             }
 
             val deleted = memberExposedRepository.deleteMemberByEmail(email)

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/ScoreExposedRepository.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/ScoreExposedRepository.kt
@@ -59,8 +59,6 @@ interface ScoreExposedRepository {
         categoryType: CategoryType,
     ): Score?
 
-    fun deleteByIdIn(scoreIds: List<Long>)
-
     fun findByMemberIdAndCategoryTypeAndStatus(
         memberId: Long,
         categoryType: CategoryType?,

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/impl/ScoreExposedRepositoryImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/impl/ScoreExposedRepositoryImpl.kt
@@ -224,11 +224,6 @@ class ScoreExposedRepositoryImpl : ScoreExposedRepository {
                 row.toScore(member)
             }.singleOrNull()
 
-    override fun deleteByIdIn(scoreIds: List<Long>) {
-        if (scoreIds.isEmpty()) return
-        ScoreExposedEntity.deleteWhere { ScoreExposedEntity.id inList scoreIds }
-    }
-
     override fun findByMemberIdAndCategoryTypeAndStatus(
         memberId: Long,
         categoryType: CategoryType?,


### PR DESCRIPTION
## 작업 내용
> #97 PR에서 `deleteByIdIn` 메서드가 추가되었는데 `deleteAllByIdIn` 메서드가 이미 정의되어 있어서 이 메서드를 사용하도록 수정하였습니다.

## 리뷰 시 참고사항
> 
## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?