### PR TITLE
`@gsm.hs.kr` 이메일 도메인만 인증 가능하도록 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/OAuthAuthenticationServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/OAuthAuthenticationServiceImpl.kt
@@ -73,7 +73,7 @@ class OAuthAuthenticationServiceImpl(
             val name = (oauth2User.attributes["name"] as? String) ?: ""
 
             if (email.endsWith("@gsm.hs.kr").not()) {
-                throw GsmcException(ErrorCode.AUTHENTICATION_FAILED)
+                throw GsmcException(ErrorCode.INVALID_EMAIL_DOMAIN)
             }
 
             val member =

--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/common/error/ErrorCode.kt
@@ -41,6 +41,7 @@ enum class ErrorCode(
     REFRESH_TOKEN_INVALID("리프레시 토큰이 만료되었거나 유효하지 않습니다.", 401),
     OAUTH2_AUTHORIZATION_FAILED("OAuth 2.0 인증에 실패했습니다.", 401),
     AUTHENTICATION_FAILED("인증 과정에서 오류가 발생했습니다.", 401),
+    INVALID_EMAIL_DOMAIN("허용되지 않는 이메일 도메인입니다.", 403),
 
     // Member
     MEMBER_NOT_FOUND("존재하지 않는 사용자입니다.", 404),


### PR DESCRIPTION
## 작업 내용
> 해당 서비스를 인증할 때 `@gsm.hs.kr` 도메인을 가진 이메일만 인증되도록 수정하였습니다.

## 리뷰 시 참고사항
>

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?