### PR TITLE
`current` 키워드를 적절히 `my` 키워드로 변경

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/member/presentation/controller/MemberController.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/member/presentation/controller/MemberController.kt
@@ -82,8 +82,8 @@ class MemberController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @GetMapping("/current")
-    fun getCurrentMember(): GetMemberResponse = findMyMemberService.execute()
+    @GetMapping("/my")
+    fun getMyMember(): GetMemberResponse = findMyMemberService.execute()
 
     @Operation(
         summary = "사용자 단건 조회",

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/project/presentation/controller/ProjectController.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/project/presentation/controller/ProjectController.kt
@@ -165,8 +165,8 @@ class ProjectController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @GetMapping("/current")
-    fun getCurrentProjects(): List<GetProjectResponse> = findMyProjectsService.execute()
+    @GetMapping("/my")
+    fun getMyProjects(): List<GetProjectResponse> = findMyProjectsService.execute()
 
     @Operation(summary = "프로젝트 단건 조회", description = "프로젝트 ID로 프로젝트를 조회합니다")
     @ApiResponses(


### PR DESCRIPTION
## 작업 내용
> #45 이슈를 해결하기 위하여 작업을 진행하였습니다.`currentMemberProvider`와 같이 기존 키워드가 더 의미상 자연스럽다면 변경하지 않았습니다.

## 리뷰 시 참고사항
> @team-incube/frontend 클라이언트에도 작업이 필요할 것 같습니다.변경된 엔드포인트는 다음과 같습니다.
  - `/api/v3/projects/current` → `/api/v3/projects/my`
  - `/api/v3/members/current` → `/api/v3/members/my`


## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?