### PR TITLE
엔드포인트 별 접근권한 설정 추가

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/security/config/DomainAuthorizationConfig.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/security/config/DomainAuthorizationConfig.kt
@@ -17,7 +17,7 @@ class DomainAuthorizationConfig {
             .permitAll()
             // Auth
             .requestMatchers("/api/v3/auth/signup")
-            .hasRole("UNAUTHORIZED")
+            .hasRole(MemberRole.UNAUTHORIZED.name)
             .requestMatchers("/api/v3/auth/**")
             .permitAll()
             // Developer
@@ -25,47 +25,47 @@ class DomainAuthorizationConfig {
             .permitAll()
             // Alert
             .requestMatchers("/api/v3/alerts/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // Category
             .requestMatchers("/api/v3/categories/**")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             // Evidence
             .requestMatchers(HttpMethod.GET, "/api/v3/evidences/my", "/api/v3/evidences/draft")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers(HttpMethod.POST, "/api/v3/evidences/draft")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers(HttpMethod.DELETE, "/api/v3/evidences/draft")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers("/api/v3/evidences/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // File
             .requestMatchers(HttpMethod.GET, "/api/v3/files/my", "/api/v3/files/my/unused")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers("/api/v3/files/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // Member
             .requestMatchers("/api/v3/members/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // Project
             .requestMatchers(HttpMethod.GET, "/api/v3/projects/draft", "/api/v3/projects/*/my-score-and-evidence")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers(HttpMethod.POST, "/api/v3/projects/draft")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers(HttpMethod.DELETE, "/api/v3/projects/draft")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers("/api/v3/projects/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // Score
             .requestMatchers(HttpMethod.POST, "/api/v3/scores/volunteer", "/api/v3/scores/academic-grade")
-            .hasAnyRole("TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             .requestMatchers(HttpMethod.PUT, "/api/v3/scores/*/status")
-            .hasAnyRole("TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             .requestMatchers(HttpMethod.PATCH, "/api/v3/scores/*/approve", "/api/v3/scores/*/reject")
-            .hasAnyRole("TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             .requestMatchers(HttpMethod.GET, "/api/v3/scores/total/*", "/api/v3/scores/by-category/*")
-            .hasAnyRole("TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             .requestMatchers(HttpMethod.GET, "/api/v3/scores", "/api/v3/scores/by-category", "/api/v3/scores/total")
-            .hasRole("STUDENT")
+            .hasRole(MemberRole.STUDENT.name)
             .requestMatchers(
                 HttpMethod.POST,
                 "/api/v3/scores/certificate",
@@ -79,12 +79,12 @@ class DomainAuthorizationConfig {
                 "/api/v3/scores/newrrow-school",
                 "/api/v3/scores/external-activity",
                 "/api/v3/scores/project-participation",
-            ).hasRole("STUDENT")
+            ).hasRole(MemberRole.STUDENT.name)
             .requestMatchers("/api/v3/scores/**")
-            .hasAnyRole("STUDENT", "TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.STUDENT.name, MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             // Sheet
             .requestMatchers("/api/v3/sheets/**")
-            .hasAnyRole("TEACHER", "HOMEROOM_TEACHER", "ROOT")
+            .hasAnyRole(MemberRole.TEACHER.name, MemberRole.HOMEROOM_TEACHER.name, MemberRole.ROOT.name)
             .anyRequest()
             .authenticated()
     }


### PR DESCRIPTION
## 작업 사항  
기존 permitAll() 또는 단순한 권한 설정에서 도메인별, HTTP 메서드별 세밀한 권한 제어로 개선했습니다.

  주요 권한 설정:
  - Auth: 회원가입(/signup)은 UNAUTHORIZED만, 나머지는 permitAll
  - Developer: 모든 경로 permitAll
  - Alert: 전체 권한 (STUDENT, TEACHER, HOMEROOM_TEACHER, ROOT)
  - Category: STUDENT만 접근 가능
  - Evidence: 임시저장 및 내 증빙자료 조회는 STUDENT만, 나머지는 전체 권한
  - File: 내 파일 목록/미사용 파일은 STUDENT만, 나머지는 전체 권한
  - Member: 전체 권한
  - Project: 임시저장 및 내 프로젝트 점수/증빙은 STUDENT만, 나머지는 전체 권한
  - Score:
    - 선생님만: 봉사/교과 점수 추가, 승인/거절, 특정 사용자 조회
    - 학생만: 일반 점수 조회/추가 (자격증, 수상, TOPCIT 등)
    - 전체 권한: 점수 단건 조회, 수정 등
  - Sheet: 선생님만 접근 가능

  2. 코드 구조 개선

  - 도메인별 그룹핑: 같은 도메인의 설정을 한 곳에 모아 가독성 향상
  - 주석 간소화: 상세 설명 제거, 도메인명만 표시 (// Auth, // Score 등)
  - 타입 안정성 강화: 하드코딩된 문자열 대신 MemberRole enum 사용
  // Before
  .hasRole("STUDENT")

  // After
  .hasRole(MemberRole.STUDENT.name)

  3. 보안 강화

  - 각 도메인별로 역할에 맞는 최소 권한 원칙 적용
  - HTTP 메서드별 세밀한 권한 제어로 불필요한 접근 차단
  - 회원가입 경로는 미인증 사용자만 접근 가능하도록 제한

 ## 리뷰 시 참고사항

  1. 권한 설정 검증 필요
    - 각 도메인별 권한 설정이 비즈니스 요구사항과 일치하는지 확인 필요
    - 특히 Score 도메인의 세밀한 권한 분리가 실제 사용 시나리오에 맞는지 검토 부탁드립니다
  2. MemberRole enum 사용
    - 하드코딩된 문자열 대신 MemberRole.STUDENT.name 형태로 변경하여 타입 안정성 확보
    - 추후 권한명 변경 시 한 곳만 수정하면 되도록 개선
  3. 도메인 순서
    - 알파벳 순서로 정렬하여 일관성 유지
    - 필요 시 도메인 순서 변경 가능


## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?