### PR TITLE
인증 객체 설정 시 인증 권한 문자열을 올바르게 사용하도록 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/global/security/jwt/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/global/security/jwt/filter/JwtAuthenticationFilter.kt
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.web.filter.OncePerRequestFilter
@@ -31,7 +30,7 @@ class JwtAuthenticationFilter(
         if (token != null && jwtParser.validateAccessToken(token)) {
             val userId = jwtParser.getUserIdFromAccessToken(token).toLong()
             val role = jwtParser.getRoleFromAccessToken(token)
-            val authorities: List<GrantedAuthority> = listOf(SimpleGrantedAuthority("ROLE_${role.name}"))
+            val authorities: List<GrantedAuthority> = listOf(role)
             val authentication =
                 UsernamePasswordAuthenticationToken(userId, null, authorities)
             authentication.details = WebAuthenticationDetailsSource().buildDetails(request)


### PR DESCRIPTION
## 작업 내용
> 인증 객체 설정 시 권한 정보를 저장할 때 `ROLE_`를 추가로 앞에 설정하여 Spring Security가 올바르게 설정하도록 재구성하였습니다.

## 리뷰 시 참고사항
> 
## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?