### PR TITLE
이메일 도메인 검증을 개발환경에서는 비활성화 하도록 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/OAuthAuthenticationServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/OAuthAuthenticationServiceImpl.kt
@@ -20,6 +20,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthorizationException
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse
+import org.springframework.core.env.Environment
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import java.net.URLDecoder
@@ -34,6 +35,7 @@ class OAuthAuthenticationServiceImpl(
     private val tokenResponseClient: OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>,
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val refreshTokenRedisRepository: RefreshTokenRedisRepository,
+    private val environment: Environment,
 ) : OAuthAuthenticationService {
     override fun execute(code: String): AuthTokenResponse {
         val decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8)
@@ -72,7 +74,8 @@ class OAuthAuthenticationServiceImpl(
                     ?: throw GsmcException(ErrorCode.AUTHENTICATION_FAILED)
             val name = (oauth2User.attributes["name"] as? String) ?: ""
 
-            if (email.endsWith("@gsm.hs.kr").not()) {
+            val isDevProfile = environment.activeProfiles.contains("dev")
+            if (!isDevProfile && email.endsWith("@gsm.hs.kr").not()) {
                 throw GsmcException(ErrorCode.INVALID_EMAIL_DOMAIN)
             }
 


### PR DESCRIPTION
## 작업 내용
> 활성화된 프로파일이 `dev`라면 `@gsm.hs.kr` 이메일 도메인 인증을 비활성화 하도록 수정하였습니다.

## 리뷰 시 참고사항
> 

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?