### PR TITLE
교직원 회원가입 로직에서 트랜젝션 범위 설정 문제 해결

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/CreateTeacherSignUpRequestServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/auth/service/impl/CreateTeacherSignUpRequestServiceImpl.kt
@@ -27,25 +27,27 @@ class CreateTeacherSignUpRequestServiceImpl(
         grade: Int?,
         classNumber: Int?,
     ) {
-        val currentMember = currentMemberProvider.getCurrentMember()
         if (requestedRole != MemberRole.TEACHER && requestedRole != MemberRole.HOMEROOM_TEACHER) {
             throw GsmcException(ErrorCode.INVALID_TEACHER_ROLE)
         }
         if (requestedRole == MemberRole.HOMEROOM_TEACHER && (grade == null || classNumber == null)) {
             throw GsmcException(ErrorCode.HOMEROOM_TEACHER_GRADE_CLASS_REQUIRED)
         }
-        val request =
-            TeacherSignUpRequestRedisEntity(
-                memberId = currentMember.id,
-                name = name,
-                email = currentMember.email,
-                requestedRole = requestedRole,
-                grade = grade,
-                classNumber = classNumber,
-                requestedAt = Instant.now(),
-            )
-        teacherSignUpRequestRedisRepository.save(request)
+
         transaction {
+            val currentMember = currentMemberProvider.getCurrentMember()
+            val request =
+                TeacherSignUpRequestRedisEntity(
+                    memberId = currentMember.id,
+                    name = name,
+                    email = currentMember.email,
+                    requestedRole = requestedRole,
+                    grade = grade,
+                    classNumber = classNumber,
+                    requestedAt = Instant.now(),
+                )
+            teacherSignUpRequestRedisRepository.save(request)
+
             val targetMembers =
                 memberExposedRepository.findAllByRoleIn(
                     listOf(MemberRole.TEACHER, MemberRole.HOMEROOM_TEACHER, MemberRole.ROOT),


### PR DESCRIPTION
## 작업 내용
> 교직원 회원가입 로직에서 현재 인증된 사용자 정보를 가져올 때 트랜젝션 범위 설정이 올바르게 되지 않아 트랜젝션 외부에서 쿼리 시도를 하는 문제를 해결하였습니다.

## 리뷰 시 참고사항
>

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?