### PR TITLE
회원 삭제 시 FK 제약 조건 오류 해결

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
@@ -34,6 +34,17 @@ class DeleteMemberByEmailServiceImpl(
 
             alertExposedRepository.deleteAllByMemberId(member.id)
 
+            val memberFiles = fileExposedRepository.findAllByUserId(member.id)
+            val memberFileIds = memberFiles.map { it.id }
+
+            memberFiles.forEach { file ->
+                s3DeleteService.execute(file.uri)
+            }
+
+            if (memberFileIds.isNotEmpty()) {
+                fileExposedRepository.deleteAllByIdIn(memberFileIds)
+            }
+
             val scores = scoreExposedRepository.findAllByMemberId(member.id)
             if (scores.isNotEmpty()) {
                 val scoreIds = scores.mapNotNull { it.id }


### PR DESCRIPTION
## 작업 내용
`findAllByUserId`, `deleteAllByIdIn`을 사용해 member를 직접 참조하는 file 데이터를 삭제하여 FK 제약 오류를 해결하는 로직을 추가하였습니다.

## 리뷰 시 참고사항


## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?