### PR TITLE
회원 탈퇴 시 삭제 순서 조정으로 FK 제약 오류 해결

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
@@ -30,12 +30,33 @@ class DeleteMemberByEmailServiceImpl(
         transaction {
             val member =
                 memberExposedRepository.findByEmail(email)
-                    ?: run {
-                        logger().info("Member withdrawal failed: member not found. email={}", email)
-                        throw GsmcException(ErrorCode.MEMBER_NOT_FOUND)
-                    }
+                    ?: throw GsmcException(ErrorCode.MEMBER_NOT_FOUND)
 
             alertExposedRepository.deleteAllByMemberId(member.id)
+
+            val scores = scoreExposedRepository.findAllByMemberId(member.id)
+            val scoreIds = scores.mapNotNull { it.id }
+
+            scores.forEach { score ->
+                val sourceId = score.sourceId ?: return@forEach
+
+                when (score.categoryType.evidenceType) {
+                    EvidenceType.EVIDENCE -> {
+                        evidenceExposedRepository.deleteById(sourceId)
+                    }
+
+                    EvidenceType.FILE,
+                    EvidenceType.UNREQUIRED,
+                    -> {
+                        Unit
+                    }
+                }
+            }
+
+            if (scoreIds.isNotEmpty()) {
+                alertExposedRepository.deleteAllByScoreIdIn(scoreIds)
+                scoreExposedRepository.deleteAllByIdIn(scoreIds)
+            }
 
             val memberFiles = fileExposedRepository.findAllByUserId(member.id)
             val memberFileIds = memberFiles.map { it.id }
@@ -48,39 +69,12 @@ class DeleteMemberByEmailServiceImpl(
                 ProjectFileExposedEntity.deleteWhere {
                     ProjectFileExposedEntity.file inList memberFileIds
                 }
+
                 fileExposedRepository.deleteAllByIdIn(memberFileIds)
-            }
-
-            val scores = scoreExposedRepository.findAllByMemberId(member.id)
-            if (scores.isNotEmpty()) {
-                val scoreIds = scores.mapNotNull { it.id }
-
-                if (scoreIds.isNotEmpty()) {
-                    alertExposedRepository.deleteAllByScoreIdIn(scoreIds)
-                }
-
-                scores.forEach { score ->
-                    val sourceId = score.sourceId ?: return@forEach
-
-                    when (score.categoryType.evidenceType) {
-                        EvidenceType.EVIDENCE -> {
-                            evidenceExposedRepository.deleteById(sourceId)
-                        }
-
-                        EvidenceType.FILE,
-                        EvidenceType.UNREQUIRED,
-                        -> {
-                            Unit
-                        }
-                    }
-                }
-
-                scoreExposedRepository.deleteAllByIdIn(scoreIds)
             }
 
             val deleted = memberExposedRepository.deleteMemberByEmail(email)
             if (deleted == 0) {
-                logger().warn("Member withdrawal failed unexpectedly after it was found. email={}", email)
                 throw GsmcException(ErrorCode.MEMBER_NOT_FOUND)
             }
         }


### PR DESCRIPTION
## 작업 내용
`tb_file` 삭제 전에 `tb_evidence`가 삭제되며 FK로 매핑되어있던 `tb_evidence_file`이 먼저 삭제되는 문제를 삭제 순서를 변경하여 해결하였습니다.

## 리뷰 시 참고사항
> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.
> 구현 중 고민이나 특정 부분에 대한 설명 등을 작성하면 좋습니다.
> e.g. 이 부분은 이렇게 구현했는데, 이게 맞는 방향인지 궁금합니다.

## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?