### PR TITLE
회원 탈퇴 시 프로젝트 선삭제로 FK 제약 오류 해결

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/developer/service/impl/DeleteMemberByEmailServiceImpl.kt
@@ -7,6 +7,7 @@ import com.team.incube.gsmc.v3.domain.evidence.repository.EvidenceExposedReposit
 import com.team.incube.gsmc.v3.domain.file.repository.FileExposedRepository
 import com.team.incube.gsmc.v3.domain.member.repository.MemberExposedRepository
 import com.team.incube.gsmc.v3.domain.project.entity.ProjectFileExposedEntity
+import com.team.incube.gsmc.v3.domain.project.repository.ProjectExposedRepository
 import com.team.incube.gsmc.v3.domain.score.repository.ScoreExposedRepository
 import com.team.incube.gsmc.v3.global.common.error.ErrorCode
 import com.team.incube.gsmc.v3.global.common.error.exception.GsmcException
@@ -24,6 +25,7 @@ class DeleteMemberByEmailServiceImpl(
     private val alertExposedRepository: AlertExposedRepository,
     private val evidenceExposedRepository: EvidenceExposedRepository,
     private val fileExposedRepository: FileExposedRepository,
+    private val projectExposedRepository: ProjectExposedRepository,
     private val s3DeleteService: S3DeleteService,
 ) : DeleteMemberByEmailService {
     override fun execute(email: String) {
@@ -69,8 +71,13 @@ class DeleteMemberByEmailServiceImpl(
                 ProjectFileExposedEntity.deleteWhere {
                     ProjectFileExposedEntity.file inList memberFileIds
                 }
-
                 fileExposedRepository.deleteAllByIdIn(memberFileIds)
+            }
+
+            val ownedProjects = projectExposedRepository.findProjectsByOwnerId(member.id)
+            ownedProjects.forEach { project ->
+                val projectId = project.id ?: return@forEach
+                projectExposedRepository.deleteProjectById(projectId)
             }
 
             val deleted = memberExposedRepository.deleteMemberByEmail(email)


### PR DESCRIPTION
## 작업 내용
멤버 삭제시 해당 회원이 소유한 프로젝트를 삭제하지 않은 상태에서 회원을 먼저 삭제해 `tb_project.owner_id → tb_member.member_id` 에서 FK 제약 위반이 발생한 오류를 해결하였습니다.
## 리뷰 시 참고사항
> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.
> 구현 중 고민이나 특정 부분에 대한 설명 등을 작성하면 좋습니다.
> e.g. 이 부분은 이렇게 구현했는데, 이게 맞는 방향인지 궁금합니다.

## 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [ ] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [ ] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?