### PR TITLE
거부된 인증제 점수가 인증제 점수 총합에 포함되지 않도록 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/impl/ScoreExposedRepositoryImpl.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/repository/impl/ScoreExposedRepositoryImpl.kt
@@ -130,7 +130,8 @@ class ScoreExposedRepositoryImpl : ScoreExposedRepository {
             .selectAll()
             .where {
                 (ScoreExposedEntity.member eq memberId) and
-                    (ScoreExposedEntity.categoryEnglishName eq categoryType.englishName)
+                    (ScoreExposedEntity.categoryEnglishName eq categoryType.englishName) and
+                    (ScoreExposedEntity.status neq ScoreStatus.REJECTED)
             }.count()
 
     override fun findAllByMemberId(memberId: Long): List<Score> {


### PR DESCRIPTION
## 작업 내용
> 거부 상태의 인증제 점수가 총합계에 포함되지 않도록 수정하여 사용자의 인증제 점수 작성이 교착상태에 빠지지 않도록 하였습니다.

## 리뷰 시 참고사항
>

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?