### PR TITLE
실제 API의 동작과 일치하지 않던 HTTP 메서드들을 수정

### DIFF
--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/presentation/ScoreController.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/presentation/ScoreController.kt
@@ -273,7 +273,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/topcit")
+    @PutMapping("/topcit")
     fun addTopcitScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -302,7 +302,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/toeic")
+    @PutMapping("/toeic")
     fun addToeicScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -321,7 +321,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/toeic-academy")
+    @PutMapping("/toeic-academy")
     fun addToeicAcademyScore(): CreateScoreResponse = createToeicAcademyScoreService.execute()
 
     @Operation(summary = "JLPT 영역 인증제 점수 추가 또는 갱신", description = "현재 인증된 사용자의 JLPT 영역에 대한 인증제 점수를 추가하거나 갱신합니다")
@@ -344,7 +344,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/jlpt")
+    @PutMapping("/jlpt")
     fun addJlptScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -373,7 +373,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/read-a-thon")
+    @PutMapping("/read-a-thon")
     fun addReadAThonScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -397,7 +397,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/volunteer")
+    @PutMapping("/volunteer")
     fun addVolunteerScore(
         @Valid @RequestBody request: CreateScoreWithValueRequest,
     ): CreateScoreResponse = createVolunteerScoreService.execute(value = request.value)
@@ -422,7 +422,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/ncs")
+    @PutMapping("/ncs")
     fun addNcsScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -451,7 +451,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/newrrow-school")
+    @PutMapping("/newrrow-school")
     fun addNewrrowSchoolScore(
         @Valid @RequestBody request: CreateScoreWithValueAndFileRequest,
     ): CreateScoreResponse =
@@ -475,7 +475,7 @@ class ScoreController(
         ],
     )
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/academic-grade")
+    @PutMapping("/academic-grade")
     fun addAcademicGradeScore(
         @Valid @RequestBody request: CreateScoreWithValueRequest,
     ): CreateScoreResponse = createAcademicGradeScoreService.execute(value = request.value)

--- a/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/presentation/ScoreController.kt
+++ b/src/main/kotlin/com/team/incube/gsmc/v3/domain/score/presentation/ScoreController.kt
@@ -311,7 +311,7 @@ class ScoreController(
             fileId = request.fileId,
         )
 
-    @Operation(summary = "토익사관학교 참여 등록 또는 개신", description = "현재 인증된 사용자의 토익사관학교 참여를 등록 또는 갱신합니다")
+    @Operation(summary = "토익사관학교 참여 등록 또는 갱신", description = "현재 인증된 사용자의 토익사관학교 참여를 등록 또는 갱신합니다")
     @ApiResponses(
         value = [
             ApiResponse(


### PR DESCRIPTION
## 작업 내용
> 인증제 점수 API들중 실제론 `PUT`에 해당하는 동작을 하는 API들이 `POST`로 되어 있던 것을 수정하였습니다.

## 리뷰 시 참고사항
> API의 스펙이 바뀌는 크리티컬한 변경이여서 @team-incube/gsmc-client 쪽도 작업이 끝나면 병합하는게 좋을 것 같습니다.

## 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서를 작성 또는 수정했나요? (e.g. `README`, `.env.example`)
- [x] 작업한 코드가 정상적으로 동작하는지 확인했나요?
- [x] 작업한 코드에 대한 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] 해당 PR과 관련 없는 작업이 포함되지는 않았나요?
- [x] PR의 올바른 라벨과 리뷰어를 설정했나요?